### PR TITLE
change regex for parsing harmony response - makes it work on mono/pi

### DIFF
--- a/HarmonyHub/HarmonyClient.cs
+++ b/HarmonyHub/HarmonyClient.cs
@@ -170,7 +170,7 @@ namespace HarmonyHub
                 // Activity commands send 100 (continue) until they finish
                 if (iq.InnerXml.Contains("errorcode=\"200\""))
                 {
-                    const string identityRegEx = "errorstring=\"OK\">(.*)</oa>";
+                    const string identityRegEx = "\">(.*)</oa>";
                     var regex = new Regex(identityRegEx, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
                     switch (_clientCommand)


### PR DESCRIPTION
I found that the exact sequence of text returned in the data from the harmony hub was a little different when running on mono on the pi. This caused the parsing code to not detect a successful response. I changed the regex to be less restrictive and now it works.